### PR TITLE
Ignore subdomains of the ignored domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ try {
   const comment = payload.comment ? payload.comment.body : payload.issue.body;
   console.log(`comment: ${comment}`)
   const exemptDomainsInput = core.getInput('exemptions')
-  const exemptDomains = exemptDomainsInput.split(',').map(d => d.toLowerCase()).map(d => '@' + d);
+  const exemptDomains = exemptDomainsInput.split(',').map(d => d.toLowerCase()).map(d => d);
   const ignoredEmailsInput = core.getInput('ignoredEmails');
   const ignoredEmails = ignoredEmailsInput.split(',').map(e => e.toLowerCase());
   console.log(`Exempt domains: ${exemptDomains}`);


### PR DESCRIPTION
This PR will remove the appending '@' chars to correct expected behavior:

assume exemptedDomains: test, flowcrypt.com

processed exemptedDomains: @test, @flowcrypt.com
current behavior: demo@hello.test - produces unwanted comment notification

processed exemptedDomains: test, flowcrypt.com
corrected behavior: demo@hello.test - do not show comment notification